### PR TITLE
Publish artifacts to maven-public

### DIFF
--- a/.github/workflows/post-issue-to-card.yml
+++ b/.github/workflows/post-issue-to-card.yml
@@ -1,0 +1,14 @@
+name: Post issue to card
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened]
+
+jobs:
+  find-issue-number:
+    name: Post issue to card
+    runs-on: ubuntu-latest
+    steps:
+      - uses: svvsaga/github-actions-public/post-issue-to-card@main
+        with:
+          apikey: ${{ secrets.KANBANIZE_API_KEY }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -58,6 +58,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          version: latest
+          service_account_key: ${{ secrets.GCP_SA_ARTIFACT_PUBLISHER }}
+          export_default_credentials: true
+
       - name: Publish packages
         run: ./gradlew publish -PreleaseVersion=$RELEASE_VERSION
         working-directory: ${{ matrix.path }}

--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     `maven-publish`
     `version-catalog`
     id("com.github.jk1.dependency-license-report") version "2.0"
+    id("com.google.cloud.artifactregistry.gradle-plugin") version "2.1.4"
 }
 
 val kotlinVersion = "1.5.31"
@@ -28,6 +29,7 @@ allprojects {
     version = modulesVersion
 
     apply(plugin = "maven-publish")
+    apply(plugin = "com.google.cloud.artifactregistry.gradle-plugin")
 
     publishing {
         repositories {
@@ -38,6 +40,10 @@ allprojects {
                     username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
                     password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
                 }
+            }
+            maven {
+                name = "GoogleArtifacts"
+                url = uri("artifactregistry://europe-maven.pkg.dev/saga-artifacts/maven-public")
             }
         }
     }

--- a/plugins/saga-build/build.gradle.kts
+++ b/plugins/saga-build/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `kotlin-dsl`
     `maven-publish`
+    id("com.google.cloud.artifactregistry.gradle-plugin") version "2.1.4"
 }
 
 group = "no.vegvesen.saga"
@@ -28,6 +29,10 @@ publishing {
                 username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_ACTOR")
                 password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
             }
+        }
+        maven {
+            name = "GoogleArtifacts"
+            url = uri("artifactregistry://europe-maven.pkg.dev/saga-artifacts/maven-public")
         }
     }
 }


### PR DESCRIPTION
KB-7071

Since GitHub Package Registry does not currently support anonymous usage of public packages
(see https://github.community/t/how-to-allow-unauthorised-read-access-to-github-packages-maven-repository/115517/8),
we also publish to a public Maven Repo in our Google Artifact Registry.
