### PR TITLE
Use Google artifact registry in SagaBuildPlugin

### DIFF
--- a/plugins/saga-build/src/main/kotlin/SagaBuildPlugin.kt
+++ b/plugins/saga-build/src/main/kotlin/SagaBuildPlugin.kt
@@ -12,8 +12,8 @@ class SagaBuildPlugin : Plugin<Project> {
                 maven("https://packages.confluent.io/maven") // Needed by beam-runners-google-cloud-dataflow-java
                 maven("https://jitpack.io")
                 maven {
-                    name = "GitHubPackages"
-                    url = uri("https://maven.pkg.github.com/svvsaga/gradle-modules-public")
+                    name = "GoogleArtifactRegistry"
+                    url = uri("https://europe-maven.pkg.dev/saga-artifacts/maven-public")
                 }
             }
         }


### PR DESCRIPTION
The Saga Build plugin must be updated to point at Google Artifact Registry instead of GitHub Packages.
This will allow consumers of the plugin to not have to add the repository in every project.