### PR TITLE
Add workflow for building and testing on PR and merge to main

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,52 @@
+name: Build and test on PR and merge to main
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.kts"
+      - "**/*.kt"
+      - "**/*.java"
+      - "**/*.gradle"
+  pull_request:
+    paths:
+      - "**/*.kts"
+      - "**/*.kt"
+      - "**/*.java"
+      - "**/*.gradle"
+
+jobs:
+  find-module-changes:
+    name: Find module changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Find modules with changes
+        id: find-module-changes
+        uses: svvsaga/github-actions-public/find-gradle-module-changes@v3.3.3
+        with:
+          token: ${{ github.token }}
+    outputs:
+      matrix: ${{ steps.find-module-changes.outputs.matrix }}
+      has_results: ${{ steps.find-module-changes.outputs.has_results }}
+
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    if: needs.find-module-changes.outputs.has_results == 'true'
+    needs: find-module-changes
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find-module-changes.outputs.matrix) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.path }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Gradle build and test
+        run: ./gradlew test


### PR DESCRIPTION
KB-7070

To ensure modules build as part of PR, and when merging to main, we check for changes and build and test all changed modules.
