### PR TITLE
Do not overwrite Datex publications

### DIFF
--- a/modules/datex/src/main/kotlin/no/vegvesen/saga/modules/datex/DatexStorageRepository.kt
+++ b/modules/datex/src/main/kotlin/no/vegvesen/saga/modules/datex/DatexStorageRepository.kt
@@ -47,7 +47,7 @@ class DatexStorageRepository(
             StoragePath(datexDataBucketName, filePath(publicationTime)),
             data.value,
             contentType,
-            SaveFileOptions(gzipContent = gzipped, customTime = publicationTime)
+            SaveFileOptions(gzipContent = gzipped, customTime = publicationTime, noOverwrite = true)
         )
             .mapLeft { ex -> DatexStorageError.Exception(ex.toString(), ex) }
 

--- a/modules/datex/src/test/kotlin/no/vegvesen/saga/modules/datex/DatexStorageRepositoryTests.kt
+++ b/modules/datex/src/test/kotlin/no/vegvesen/saga/modules/datex/DatexStorageRepositoryTests.kt
@@ -1,6 +1,7 @@
 package no.vegvesen.saga.modules.datex
 
 import arrow.core.right
+import io.kotest.assertions.arrow.either.shouldBeRight
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.nulls.shouldBeNull
@@ -79,6 +80,18 @@ class DatexStorageRepositoryTests : AnnotationSpec() {
                 ContentType.Xml,
                 withArg { it.gzipContent shouldBe true }
             )
+        }
+    }
+
+    @Test
+    suspend fun `should not overwrite files`() {
+        val pubTime = ZonedDateTime.parse("2020-05-03T14:21:41+02:00").toInstant()
+        coEvery { testBlobStorage.saveFile(any(), any(), ContentType(any()), any(), any()) } returns Unit.right()
+
+        repository.saveObject(testData, pubTime, true, ContentType.Xml).shouldBeRight()
+
+        coVerify {
+            testBlobStorage.saveFile(any(), any(), ContentType(any()), match { it.noOverwrite }, any())
         }
     }
 }


### PR DESCRIPTION
KB-6763

To avoid errors when ingesting publications without rights to delete documents.
