### PR TITLE
Use correct method of saving file without overwriting

### DIFF
--- a/modules/datex/src/main/kotlin/no/vegvesen/saga/modules/datex/DatexStorageRepository.kt
+++ b/modules/datex/src/main/kotlin/no/vegvesen/saga/modules/datex/DatexStorageRepository.kt
@@ -42,12 +42,12 @@ class DatexStorageRepository(
         publicationTime: Instant,
         gzipped: Boolean,
         contentType: ContentType
-    ): Either<DatexStorageError, Unit> =
-        storage.saveFile(
+    ): Either<DatexStorageError, Boolean> =
+        storage.saveFileIfNotExisting(
             StoragePath(datexDataBucketName, filePath(publicationTime)),
             data.value,
             contentType,
-            SaveFileOptions(gzipContent = gzipped, customTime = publicationTime, noOverwrite = true)
+            SaveFileOptions(gzipContent = gzipped, customTime = publicationTime)
         )
             .mapLeft { ex -> DatexStorageError.Exception(ex.toString(), ex) }
 
@@ -79,10 +79,12 @@ class DatexStorageRepository(
                     else -> DatexStorageError.UnknownError("KVStore failed with unknown error", it)
                 }
             }
+
+    companion object {
+        fun lastModifiedTimeToString(date: Instant): String = date.toString()
+
+        fun stringToLastModifiedTime(data: String): Instant? = runCatching {
+            Instant.parse(data)
+        }.getOrNull()
+    }
 }
-
-internal fun lastModifiedTimeToString(date: Instant): String = date.toString()
-
-internal fun stringToLastModifiedTime(data: String): Instant? = runCatching {
-    Instant.parse(data)
-}.getOrNull()

--- a/modules/datex/src/test/kotlin/no/vegvesen/saga/modules/datex/DatexPollerTests.kt
+++ b/modules/datex/src/test/kotlin/no/vegvesen/saga/modules/datex/DatexPollerTests.kt
@@ -48,7 +48,7 @@ class DatexPollerTests : AnnotationSpec(), Logging {
                 any(),
                 ContentType.Xml
             )
-        } returns Unit.right()
+        } returns true.right()
         coEvery { datexStorageRepositoryMock.saveLastModifiedTime(testLastModifiedTime) } returns Unit.right()
     }
 
@@ -154,7 +154,7 @@ class DatexPollerTests : AnnotationSpec(), Logging {
                 any(),
                 ContentType.Xml
             )
-        } returns Unit.right()
+        } returns true.right()
 
         coEvery { datexStorageRepositoryMock.getLastModifiedTime() }.returns(Either.Right(null))
         coEvery { datexStorageRepositoryMock.saveLastModifiedTime(any()) } returns testException.left()


### PR DESCRIPTION
KB-6763

The previous try used the regular saveFile with noOverwrite = true, but this just gives an exception. We want to succeed even if the file exists.
