### PR TITLE
Add instant fixed clock

### DIFF
--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -22,7 +22,7 @@ val gcpLibrariesBomVersion = "20.6.0"
 val xmlBindVersion = "2.3.1"
 
 val modulesVersion =
-    "1.3.${(if (project.hasProperty("releaseVersion")) project.property("releaseVersion") else null) ?: "0-SNAPSHOT"}"
+    "1.4.${(if (project.hasProperty("releaseVersion")) project.property("releaseVersion") else null) ?: "0-SNAPSHOT"}"
 
 allprojects {
     group = "no.vegvesen.saga.modules"

--- a/modules/testing/src/main/kotlin/no/vegvesen/saga/modules/testing/FixedClock.kt
+++ b/modules/testing/src/main/kotlin/no/vegvesen/saga/modules/testing/FixedClock.kt
@@ -1,0 +1,10 @@
+package no.vegvesen.saga.modules.testing
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+class FixedClock(private val instant: Instant) : Clock {
+    override fun now() = instant
+}
+
+fun Instant.fixedClock() = FixedClock(this)

--- a/modules/testing/src/test/kotlin/no/vegvesen/saga/modules/testing/FixedClockTest.kt
+++ b/modules/testing/src/test/kotlin/no/vegvesen/saga/modules/testing/FixedClockTest.kt
@@ -1,0 +1,15 @@
+package no.vegvesen.saga.modules.testing
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.Instant
+
+class FixedClockTest : FunSpec({
+
+    test("Fixed clock keeps clock at instant") {
+        val instant = Instant.parse("2021-11-03T12:00:00Z")
+        val fixedClock = instant.fixedClock()
+        fixedClock.now() shouldBe instant
+        fixedClock.now() shouldBe fixedClock.now()
+    }
+})


### PR DESCRIPTION
Expose Instant.fixedClock to simplify interop between kotlinx.datetime Clocks and java.time Clocks

KB-7771