### PR TITLE
Add project extension for setting JVM version, set default to 11

### DIFF
--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -31,6 +31,8 @@ allprojects {
     group = "no.vegvesen.saga.modules"
     version = modulesVersion
 
+    useJvmTarget("11")
+
     apply(plugin = "maven-publish")
     apply(plugin = "com.google.cloud.artifactregistry.gradle-plugin")
 

--- a/plugins/saga-build/build.gradle.kts
+++ b/plugins/saga-build/build.gradle.kts
@@ -21,6 +21,12 @@ gradlePlugin {
     }
 }
 
+val kotlinVersion = "1.5.31"
+
+dependencies {
+    implementation("org.jetbrains.kotlin", "kotlin-gradle-plugin", kotlinVersion)
+}
+
 repositories {
     mavenCentral()
 }

--- a/plugins/saga-build/src/main/kotlin/ProjectExtensions.kt
+++ b/plugins/saga-build/src/main/kotlin/ProjectExtensions.kt
@@ -48,3 +48,11 @@ fun Project.useIntegrationTests() {
         }
     }
 }
+
+fun Project.useJvmTarget(version: String) {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions {
+            jvmTarget = version
+        }
+    }
+}

--- a/plugins/saga-build/src/main/kotlin/SagaBuildPlugin.kt
+++ b/plugins/saga-build/src/main/kotlin/SagaBuildPlugin.kt
@@ -16,6 +16,7 @@ class SagaBuildPlugin : Plugin<Project> {
                     url = uri("https://europe-maven.pkg.dev/saga-artifacts/maven-public")
                 }
             }
+            useJvmTarget("11")
         }
     }
 }


### PR DESCRIPTION
KB-7415

Consumers will automatically target JVM 11, but can opt out per project by setting e.g.
