### PR TITLE
Add String.capitalized() extension function #minor

### DIFF
--- a/modules/shared/src/main/kotlin/no/vegvesen/saga/modules/shared/StringExtensions.kt
+++ b/modules/shared/src/main/kotlin/no/vegvesen/saga/modules/shared/StringExtensions.kt
@@ -1,5 +1,6 @@
 package no.vegvesen.saga.modules.shared
 
+import java.util.Locale
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.contract
 
@@ -16,3 +17,7 @@ fun requireNotEmpty(value: String?): String {
     }
     return value
 }
+
+fun String.capitalized(): String = if (firstOrNull()?.isLowerCase() == true) this.replaceFirstChar {
+    it.titlecase(Locale.getDefault())
+} else this

--- a/modules/shared/src/test/kotlin/no/vegvesen/saga/modules/shared/StringExtensionsTest.kt
+++ b/modules/shared/src/test/kotlin/no/vegvesen/saga/modules/shared/StringExtensionsTest.kt
@@ -1,0 +1,27 @@
+package no.vegvesen.saga.modules.shared
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+class StringExtensionsTest : FunSpec({
+    test("capitalized on already capitalized string") {
+        val testString = "String"
+        testString.capitalized() shouldBe testString
+    }
+
+    test("capitalized on already capitalized string should return same object") {
+        val testString = "String"
+        testString.capitalized() shouldBeSameInstanceAs testString
+    }
+
+    test("capitalized should not touch empty string") {
+        val testString = ""
+        testString.capitalized() shouldBeSameInstanceAs testString
+    }
+
+    test("capitalized should capitalize") {
+        val testString = "string"
+        testString.capitalized() shouldBe "String"
+    }
+})


### PR DESCRIPTION
Since String.capitalize is deprecated with only a verbose suggested
alternative, add "capitalized" (which is also a better name because it
does not mutate).

**Checklist**

- [ ] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?