### PR TITLE
Upgrade Kotlinx Coroutines to 1.6.0 #major

### DIFF
--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 val kotlinVersion = "1.6.10"
-val kotlinxCoroutinesVersion = "1.5.2"
+val kotlinxCoroutinesVersion = "1.6.0"
 val kotlinxDateTimeVersion = "0.2.1"
 val ktorVersion = "1.6.5"
 val arrowVersion = "1.0.1"


### PR DESCRIPTION
It was released after Kotlin 1.6 and still has no 1.6.10 version:
https://blog.jetbrains.com/kotlin/2021/12/introducing-kotlinx-coroutines-1-6-0/

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?