### PR TITLE
Update dependency versions, make kotlin-reflect an api dependency

### DIFF
--- a/modules/build.gradle.kts
+++ b/modules/build.gradle.kts
@@ -19,7 +19,7 @@ val ktorVersion = "1.6.5"
 val arrowVersion = "1.0.1"
 val jacksonVersion = "2.12.3"
 val jUnitVersion = "5.7.1"
-val serializationVersion = "1.3.1"
+val serializationVersion = "1.3.2"
 val functionsVersion = "1.0.4"
 val gcpLibrariesBomVersion = "24.0.0"
 
@@ -82,7 +82,7 @@ subprojects {
         testRuntimeOnly("org.junit.jupiter", "junit-jupiter-engine", jUnitVersion)
 
         constraints {
-            implementation("org.jetbrains.kotlin", "kotlin-reflect", kotlinVersion)
+            api("org.jetbrains.kotlin", "kotlin-reflect", kotlinVersion)
             api("org.jetbrains.kotlinx", "kotlinx-datetime", kotlinxDateTimeVersion)
             api("org.jetbrains.kotlinx", "kotlinx-coroutines-core", kotlinxCoroutinesVersion)
             api("org.jetbrains.kotlinx", "kotlinx-serialization-properties", serializationVersion)

--- a/modules/shared/build.gradle.kts
+++ b/modules/shared/build.gradle.kts
@@ -2,8 +2,8 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("ch.qos.logback:logback-classic:1.2.7")
+    api("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("ch.qos.logback:logback-classic:1.2.10")
     implementation("org.jetbrains.kotlinx", "kotlinx-serialization-properties")
 
     testImplementation(project(":testing"))
@@ -14,9 +14,9 @@ dependencies {
     implementation("com.fasterxml.jackson.datatype", "jackson-datatype-jdk8")
     implementation("com.fasterxml.jackson.datatype", "jackson-datatype-jsr310")
     // should not have be exposed ie. "implementation", see Kanbanize: #3507
-    api("org.slf4j:slf4j-api:1.7.32")
+    api("org.slf4j:slf4j-api:1.7.36")
     api("net.logstash.logback:logstash-logback-encoder:7.0.1")
-    api("org.buildobjects:jproc:2.6.2")
+    api("org.buildobjects:jproc:2.8.0")
 
     api("org.jetbrains.kotlinx", "kotlinx-datetime")
 }

--- a/modules/testing/src/main/kotlin/no/vegvesen/saga/modules/testing/ResourceHelpers.kt
+++ b/modules/testing/src/main/kotlin/no/vegvesen/saga/modules/testing/ResourceHelpers.kt
@@ -1,5 +1,9 @@
 package no.vegvesen.saga.modules.testing
 
-fun Any.loadStringResourceOrThrow(file: String): String =
-    javaClass.getResourceAsStream(if (file.startsWith('/')) file else "/$file")?.readBytes()?.toString(Charsets.UTF_8)
-        ?: throw Exception("No resource '$file' exists on classpath")
+fun Any.loadStringResourceOrThrow(file: String): String = readResourceAsBytes(file).toString(Charsets.UTF_8)
+
+fun Any.readResourceAsBytes(file: String): ByteArray = readResourceAsStream(file).readBytes()
+
+fun Any.readResourceAsStream(file: String) =
+    javaClass.getResourceAsStream(if (file.startsWith('/')) file else "/$file")
+        ?: throw Exception("Missing resource: $file")


### PR DESCRIPTION
To avoid warnings about kotlin-reflect 1.5 and 1.6 crashing #patch
