### PR TITLE
Make writeJson retriable #minor

### DIFF
--- a/modules/gcp-bigquery/src/main/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/BigQueryStorageExtensions.kt
+++ b/modules/gcp-bigquery/src/main/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/BigQueryStorageExtensions.kt
@@ -3,7 +3,11 @@ package no.vegvesen.saga.modules.gcp.bigquery.storage
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
+import arrow.fx.coroutines.Schedule
 import arrow.fx.coroutines.parTraverse
+import arrow.fx.coroutines.parTraverseN
+import arrow.fx.coroutines.retry
+import com.google.api.gax.rpc.ApiException
 import com.google.cloud.bigquery.BigQuery
 import com.google.cloud.bigquery.TableDefinition
 import com.google.cloud.bigquery.TableId
@@ -15,6 +19,7 @@ import com.google.cloud.bigquery.storage.v1.ProtoSchemaConverter
 import com.google.cloud.bigquery.storage.v1.StreamWriter
 import com.google.protobuf.ByteString
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.Json
@@ -25,23 +30,28 @@ import no.vegvesen.saga.modules.shared.allLefts
 import no.vegvesen.saga.modules.shared.serializers.replacePrimitives
 import no.vegvesen.saga.modules.shared.serializers.withoutNulls
 import org.json.JSONArray
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
 
 /**
  * Use BigQuery Storage Write API to write documents to the default stream.
  */
+@ExperimentalTime
 @ExperimentalSerializationApi
 suspend fun <T> BigQuery.writeDocumentsToDefaultStream(
     documents: Collection<T>,
     serializer: SerializationStrategy<T>,
     tableId: TableId,
     chunkSize: Int = 500,
+    parallelization: Int = Runtime.getRuntime().availableProcessors()
 ) = Either.catchAndFlatten {
     val fullTableId =
         if (tableId.project == null) TableId.of(options.projectId, tableId.dataset, tableId.table) else tableId
     if (fullTableId.project == null) {
         Exception("TableId must include project!").left()
     } else if (documents.any()) {
-        val errors = writeJson(documents, serializer, fullTableId, chunkSize)
+        val errors = writeJson(documents, serializer, fullTableId, chunkSize, parallelization)
 
         if (errors.any()) {
             BigQueryStreamException("Some rows were not inserted", errors.map { it.localizedMessage }).left()
@@ -71,20 +81,44 @@ private suspend fun <T> BigQuery.writeProtoBuf(
     }.allLefts()
 
 // TODO: Related bug: https://github.com/googleapis/java-bigquerystorage/issues/1579 (and https://github.com/googleapis/java-bigquerystorage/issues/1580)
+@ExperimentalTime
 private suspend fun <T> BigQuery.writeJson(
     documents: Collection<T>,
     serializer: SerializationStrategy<T>,
     tableId: TableId,
-    chunkSize: Int
+    chunkSize: Int,
+    parallelization: Int
 ): List<Throwable> = createJsonStreamWriter(tableId)
     .use { writer ->
-        documents.chunked(chunkSize)
-            .parTraverse(Dispatchers.IO) { chunk ->
-                Either.catch {
-                    val rows = createJsonRows(chunk, serializer)
-                    writer.append(rows).get()
+        writer.writeJson(documents, serializer, chunkSize, parallelization)
+    }
+
+@ExperimentalTime
+suspend fun <T> JsonStreamWriter.writeJson(
+    documents: Collection<T>,
+    serializer: SerializationStrategy<T>,
+    chunkSize: Int = 200,
+    parallelization: Int = Runtime.getRuntime().availableProcessors(),
+    onRetry: (exception: ApiException, delay: Duration) -> Unit = { _, _ -> }
+) = documents.chunked(chunkSize)
+    .parTraverseN(Dispatchers.IO, parallelization) { chunk ->
+        Either.catch {
+            Schedule.exponential<Throwable>(1.seconds)
+                .check { input: Throwable, output ->
+                    if (input is ApiException && input.isRetryable && output < 10.seconds) {
+                        onRetry(input, output)
+                        true
+                    } else {
+                        false
+                    }
                 }
-            }
+                .retry {
+                    val rows = createJsonRows(chunk, serializer)
+                    withContext(Dispatchers.IO) {
+                        append(rows).get()
+                    }
+                }
+        }
     }.allLefts()
 
 private fun BigQuery.createJsonStreamWriter(tableId: TableId): JsonStreamWriter {

--- a/modules/gcp-bigquery/src/test/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/BigQueryStorageExtensionsIntegrationTest.kt
+++ b/modules/gcp-bigquery/src/test/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/BigQueryStorageExtensionsIntegrationTest.kt
@@ -1,0 +1,72 @@
+@file:Suppress("EXPERIMENTAL_API_USAGE") // Impossible to mark file annotations with annotations, so we ignore
+@file:UseSerializers(TimestampInstantSerializer::class)
+
+package no.vegvesen.saga.modules.gcp.bigquery.storage
+
+import com.google.cloud.bigquery.Field
+import com.google.cloud.bigquery.Schema
+import com.google.cloud.bigquery.StandardSQLTypeName
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.datetime.Instant
+import kotlinx.datetime.toJavaInstant
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.vegvesen.saga.modules.gcp.bigquery.BigQueryLocation
+import no.vegvesen.saga.modules.gcp.bigquery.createBigQuery
+import no.vegvesen.saga.modules.gcp.bigquery.fetchRowCount
+import no.vegvesen.saga.modules.gcp.bigquery.instantValue
+import no.vegvesen.saga.modules.gcp.bigquery.queryOf
+import no.vegvesen.saga.modules.shared.envOrThrow
+import no.vegvesen.saga.modules.shared.serializers.TimestampInstantSerializer
+import no.vegvesen.saga.modules.testing.IntegrationTest
+import no.vegvesen.saga.modules.testing.gcp.BigQueryTempTableWithSchema
+import kotlin.time.ExperimentalTime
+
+enum class Version {
+    V1, V2
+}
+
+@Serializable
+data class Row(val id: String, val timestamp: Instant, val version: Version)
+
+@ExperimentalTime
+@ExperimentalSerializationApi
+@Tags(IntegrationTest)
+class BigQueryStorageExtensionsIntegrationTest : FunSpec({
+
+    val projectId = envOrThrow("SAGA_INT_TEST_PROJECT_ID")
+
+    val bigQuery = createBigQuery(projectId, BigQueryLocation.EU)
+
+    val schema = Schema.of(
+        createRequiredField("id", StandardSQLTypeName.STRING),
+        createRequiredField("timestamp", StandardSQLTypeName.TIMESTAMP),
+        createRequiredField("version", StandardSQLTypeName.STRING)
+    )
+
+    val tempTable = listener(BigQueryTempTableWithSchema(bigQuery, schema))
+
+    val timestamp = Instant.parse("2022-01-01T00:00:00Z")
+
+    test("can write documents to default stream") {
+        val documents = List(2000) {
+            Row(it.toString(), timestamp, Version.V1)
+        }
+        bigQuery.writeDocumentsToDefaultStream(documents, Row.serializer(), tempTable.tableId).shouldBeRight()
+
+        bigQuery.fetchRowCount(tempTable.tableId) shouldBe 2000
+        val first =
+            bigQuery.queryOf("SELECT * FROM `${tempTable.tableId.dataset}`.`${tempTable.tableId.table}` ORDER BY id LIMIT 1")
+                .iterateAll().toList().first()
+        first["id"].stringValue shouldBe "0"
+        first["timestamp"].instantValue shouldBe timestamp.toJavaInstant()
+        first["version"].stringValue shouldBe Version.V1.toString()
+    }
+})
+
+private fun createRequiredField(name: String, type: StandardSQLTypeName) =
+    Field.newBuilder(name, type).setMode(Field.Mode.REQUIRED).build()

--- a/modules/gcp-bigquery/src/test/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/BigQueryStorageExtensionsTest.kt
+++ b/modules/gcp-bigquery/src/test/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/BigQueryStorageExtensionsTest.kt
@@ -1,70 +1,44 @@
-@file:Suppress("EXPERIMENTAL_API_USAGE") // Impossible to mark file annotations with annotations, so we ignore
-@file:UseSerializers(TimestampInstantSerializer::class)
-
 package no.vegvesen.saga.modules.gcp.bigquery.storage
 
-import com.google.cloud.bigquery.Field
-import com.google.cloud.bigquery.Schema
-import com.google.cloud.bigquery.StandardSQLTypeName
-import io.kotest.assertions.arrow.core.shouldBeRight
-import io.kotest.core.annotation.Tags
+import ch.qos.logback.classic.Level
+import com.google.api.gax.rpc.ResourceExhaustedException
+import com.google.cloud.bigquery.storage.v1.AppendRowsResponse
+import com.google.cloud.bigquery.storage.v1.JsonStreamWriter
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.shouldBe
-import kotlinx.datetime.Instant
-import kotlinx.datetime.toJavaInstant
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.UseSerializers
-import no.vegvesen.saga.modules.gcp.bigquery.BigQueryLocation
-import no.vegvesen.saga.modules.gcp.bigquery.createBigQuery
-import no.vegvesen.saga.modules.gcp.bigquery.fetchRowCount
-import no.vegvesen.saga.modules.gcp.bigquery.instantValue
-import no.vegvesen.saga.modules.gcp.bigquery.queryOf
-import no.vegvesen.saga.modules.shared.envOrThrow
-import no.vegvesen.saga.modules.shared.serializers.TimestampInstantSerializer
-import no.vegvesen.saga.modules.testing.IntegrationTest
-import no.vegvesen.saga.modules.testing.gcp.BigQueryTempTableWithSchema
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.mockk.every
+import io.mockk.mockk
+import no.vegvesen.saga.modules.testing.TestLogger
+import org.slf4j.LoggerFactory
+import kotlin.time.ExperimentalTime
 
-enum class Version {
-    V1, V2
-}
+@kotlinx.serialization.Serializable
+data class Foo(val bar: Int)
 
-@Serializable
-data class Row(val id: String, val timestamp: Instant, val version: Version)
-
-@ExperimentalSerializationApi
-@Tags(IntegrationTest)
+@ExperimentalTime
 class BigQueryStorageExtensionsTest : FunSpec({
-
-    val projectId = envOrThrow("SAGA_INT_TEST_PROJECT_ID")
-
-    val bigQuery = createBigQuery(projectId, BigQueryLocation.EU)
-
-    val schema = Schema.of(
-        createRequiredField("id", StandardSQLTypeName.STRING),
-        createRequiredField("timestamp", StandardSQLTypeName.TIMESTAMP),
-        createRequiredField("version", StandardSQLTypeName.STRING)
+    val testSubject = mockk<JsonStreamWriter>()
+    val exception = ResourceExhaustedException(
+        "No resources",
+        Exception(),
+        mockk(),
+        true
     )
 
-    val tempTable = listener(BigQueryTempTableWithSchema(bigQuery, schema))
+    val logger = LoggerFactory.getLogger(BigQueryStorageExtensionsTest::class.java)
 
-    val timestamp = Instant.parse("2022-01-01T00:00:00Z")
+    every {
+        testSubject.append(any()).get()
+    } throws exception andThenThrows exception andThenThrows exception andThen mockk<AppendRowsResponse>()
 
-    test("can write documents to default stream") {
-        val documents = List(2000) {
-            Row(it.toString(), timestamp, Version.V1)
-        }
-        bigQuery.writeDocumentsToDefaultStream(documents, Row.serializer(), tempTable.tableId).shouldBeRight()
+    test("writeJson can retry") {
+        val testLogger = TestLogger()
 
-        bigQuery.fetchRowCount(tempTable.tableId) shouldBe 2000
-        val first =
-            bigQuery.queryOf("SELECT * FROM `${tempTable.tableId.dataset}`.`${tempTable.tableId.table}` ORDER BY id LIMIT 1")
-                .iterateAll().toList().first()
-        first["id"].stringValue shouldBe "0"
-        first["timestamp"].instantValue shouldBe timestamp.toJavaInstant()
-        first["version"].stringValue shouldBe Version.V1.toString()
+        testSubject.writeJson(listOf(Foo(1)), Foo.serializer()) { exception, delay ->
+            logger.warn("Failure, delaying $delay", exception)
+        }.shouldBeEmpty()
+
+        testLogger.events.filter { it.level == Level.WARN } shouldHaveSize 3
     }
 })
-
-private fun createRequiredField(name: String, type: StandardSQLTypeName) =
-    Field.newBuilder(name, type).setMode(Field.Mode.REQUIRED).build()


### PR DESCRIPTION
Also allows specifiying number of threads to use when writing to bigquery.
Should make it easier to write to bigquery under big load without failing.