### PR TITLE
Default to log level info for less noisy defaults

### DIFF
--- a/modules/shared/src/main/resources/logback.xml
+++ b/modules/shared/src/main/resources/logback.xml
@@ -13,7 +13,7 @@
     </encoder>
   </appender>
 
-  <root level="debug">
+  <root level="info">
     <appender-ref ref="json"/>
   </root>
 

--- a/modules/testing/src/main/resources/logback-test.xml
+++ b/modules/testing/src/main/resources/logback-test.xml
@@ -13,7 +13,7 @@
         </encoder>
     </appender>
     <appender name="test" class="no.vegvesen.saga.modules.testing.TestLogger"/>
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="test"/>
         <appender-ref ref="json"/>
     </root>


### PR DESCRIPTION
This should e.g. reduce the amount of output seen from the nvdbapi client. #patch
KB-8980

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?