### PR TITLE
Add retry object to encapsulate exponential backoff retry functionality

### DIFF
--- a/modules/shared/src/main/kotlin/no/vegvesen/saga/modules/shared/Retry.kt
+++ b/modules/shared/src/main/kotlin/no/vegvesen/saga/modules/shared/Retry.kt
@@ -1,0 +1,55 @@
+package no.vegvesen.saga.modules.shared
+
+import arrow.core.Either
+import arrow.fx.coroutines.Schedule
+import arrow.fx.coroutines.retry
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+object Retry : Logging {
+
+    data class ExponentialBackoffSettings(val duration: Duration, val maxAttempts: Int)
+
+    /** Retry with exponential backoff. */
+    suspend fun <T> retry(
+        backoff: ExponentialBackoffSettings,
+        onRetry: (exception: Throwable, delay: Duration, attempts: Int) -> Unit,
+        retryable: suspend () -> T,
+    ): Either<Throwable, T> {
+        var attempts = 1
+        return Either.catch {
+            Schedule.exponential<Throwable>(backoff.duration)
+                .check { exception: Throwable, output ->
+                    onRetry(exception, output, attempts)
+                    attempts++
+                    attempts <= backoff.maxAttempts
+                }
+                .retry {
+                    retryable()
+                }
+        }
+    }
+
+    /** Retry with exponential backoff. */
+    suspend fun <T> retry(description: String, backoff: ExponentialBackoffSettings, retryable: suspend () -> T) =
+        retry(backoff, loggingRetry(description, backoff), retryable)
+
+    /** Retry with exponential backoff. Will retry on failed Eithers. */
+    suspend fun <T> retryEither(
+        description: String,
+        backoff: ExponentialBackoffSettings,
+        onRetry: (exception: Throwable, delay: Duration, attempts: Int) -> Unit = loggingRetry(description, backoff),
+        retryable: suspend () -> Either<Throwable, T>
+    ) = retry(backoff, onRetry) {
+        retryable().getOrThrow()
+    }
+
+    private fun loggingRetry(description: String, backoff: ExponentialBackoffSettings) =
+        { exception: Throwable, _: Duration, attempts: Int ->
+            log().warn(
+                "$description failed, retry attempt $attempts/${backoff.maxAttempts}. Error: {}",
+                v("error", exception.localizedMessage)
+            )
+        }
+}

--- a/modules/shared/src/test/kotlin/no/vegvesen/saga/modules/shared/RetryTest.kt
+++ b/modules/shared/src/test/kotlin/no/vegvesen/saga/modules/shared/RetryTest.kt
@@ -1,0 +1,51 @@
+package no.vegvesen.saga.modules.shared
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import io.kotest.assertions.arrow.core.shouldBeLeft
+import io.kotest.assertions.arrow.core.shouldBeRight
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import no.vegvesen.saga.modules.shared.Retry.ExponentialBackoffSettings
+import no.vegvesen.saga.modules.shared.Retry.retry
+import no.vegvesen.saga.modules.shared.Retry.retryEither
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+
+@ExperimentalTime
+class RetryTest : FunSpec({
+
+    test("will retry on thrown exceptions") {
+        var runs = 0
+        val result = retry("some-description", ExponentialBackoffSettings(0.1.seconds, 42)) {
+            if (runs++ < 2) {
+                throw Exception("err")
+            }
+            runs
+        }
+        result.shouldBeRight(3)
+        runs.shouldBeExactly(3)
+    }
+
+    test("will retry on failed eithers") {
+        var runs = 0
+        val result = retryEither("some-description", ExponentialBackoffSettings(0.1.seconds, 42)) {
+            if (runs++ < 2) Exception("err").left()
+            else runs.right()
+        }
+        result.shouldBeRight(3)
+        runs.shouldBeExactly(3)
+    }
+
+    test("will only run the given amount of times") {
+        var runs = 0
+        val result: Either<Throwable, Nothing> = retry("some-description", ExponentialBackoffSettings(0.1.seconds, 2)) {
+            runs++
+            throw Exception("err")
+        }
+        result.shouldBeLeft()
+        runs.shouldBe(2)
+    }
+})


### PR DESCRIPTION
Move retry functionality that handles Eithers into shared code KB-10680

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?