### PR TITLE
Reuse shared retry functionality in bigquery storage extensions.

### DIFF
--- a/modules/gcp-bigquery/src/main/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/ExponentialBackoffSettings.kt
+++ b/modules/gcp-bigquery/src/main/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/ExponentialBackoffSettings.kt
@@ -1,5 +1,0 @@
-package no.vegvesen.saga.modules.gcp.bigquery.storage
-
-import kotlin.time.Duration
-
-data class ExponentialBackoffSettings(val duration: Duration, val limit: Duration)

--- a/modules/gcp-bigquery/src/test/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/BigQueryStorageExtensionsTest.kt
+++ b/modules/gcp-bigquery/src/test/kotlin/no/vegvesen/saga/modules/gcp/bigquery/storage/BigQueryStorageExtensionsTest.kt
@@ -39,10 +39,12 @@ class BigQueryStorageExtensionsTest : FunSpec({
         val testLogger = TestLogger()
 
         testSubject.writeJson(listOf(Foo(1)), Foo.serializer()) { exception, delay, attempts ->
-            logger.warn("Failure, delaying $delay, attempts: $attempts", exception)
+            logger.warn("testlogging: Failure, delaying $delay, attempts: $attempts", exception)
         }.shouldBeEmpty()
 
-        testLogger.events.filter { it.level == Level.WARN } shouldHaveSize 3
+        testLogger.events
+            .filter { it.message.startsWith("testlogging") }
+            .filter { it.level == Level.WARN } shouldHaveSize 3
     }
 
     test("writeJson fails when time limit has been reached") {
@@ -56,10 +58,12 @@ class BigQueryStorageExtensionsTest : FunSpec({
             Foo.serializer(),
             backoffSettings = ExponentialBackoffSettings(0.1.seconds, 2)
         ) { exception, delay, attempts ->
-            logger.warn("Failure, delaying $delay, attempts $attempts", exception)
+            logger.warn("testlogging: Failure, delaying $delay, attempts $attempts", exception)
         }
 
         result.shouldNotBeEmpty()
-        testLogger.events.filter { it.level == Level.WARN }.shouldNotBeEmpty()
+        testLogger.events
+            .filter { it.message.startsWith("testlogging") }
+            .filter { it.level == Level.WARN }.shouldNotBeEmpty()
     }
 })

--- a/modules/shared/src/main/kotlin/no/vegvesen/saga/modules/shared/Retry.kt
+++ b/modules/shared/src/main/kotlin/no/vegvesen/saga/modules/shared/Retry.kt
@@ -15,7 +15,14 @@ object Retry : Logging {
     suspend fun <T> retry(
         description: String,
         backoff: ExponentialBackoffSettings,
-        onRetry: (exception: Throwable, delay: Duration, attempts: Int) -> Unit,
+        retryable: suspend () -> T,
+    ): Either<Throwable, T> = retry(description, backoff, { _, _, _ -> }, retryable)
+
+    /** Retry with exponential backoff. */
+    suspend fun <T> retry(
+        description: String,
+        backoff: ExponentialBackoffSettings,
+        onRetry: (exception: Throwable, delay: Duration, attempts: Int) -> Unit = { _, _, _ -> },
         retryable: suspend () -> T,
     ): Either<Throwable, T> {
         var attempts = 1
@@ -35,6 +42,13 @@ object Retry : Logging {
                 }
         }
     }
+
+    /** Retry with exponential backoff. Will retry on failed Eithers. */
+    suspend fun <T> retryEither(
+        description: String,
+        backoff: ExponentialBackoffSettings,
+        retryable: suspend () -> Either<Throwable, T>
+    ): Either<Throwable, T> = retryEither(description, backoff, { _, _, _ -> }, retryable)
 
     /** Retry with exponential backoff. Will retry on failed Eithers. */
     suspend fun <T> retryEither(


### PR DESCRIPTION
Reuse shared retry functionality in bigquery storage extensions. Also make `retry` always log warn on retries.

KB-10680

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?