### PR TITLE
Fix mistake where DatexPollerFunction could no longer be inherited from

### DIFF
--- a/modules/datex-poller/src/main/kotlin/no/vegvesen/saga/datex/poller/DatexPollerFunction.kt
+++ b/modules/datex-poller/src/main/kotlin/no/vegvesen/saga/datex/poller/DatexPollerFunction.kt
@@ -23,7 +23,7 @@ import no.vegvesen.saga.modules.shared.services.DeadLetterStorage
  * @param publicationsBucket Name of the bucket in which to store ingested publications, without gs://-prefix
  * @param deadLetterBucket Name of the bucket in which to store ingested documents that do not validate, without gs://-prefix
  */
-class DatexPollerFunction(
+abstract class DatexPollerFunction(
     private val datexUsernameSecretKey: String,
     private val datexUsernamePasswordKey: String,
     private val datexEndpointUrl: String,


### PR DESCRIPTION
I did not know that classes by default could not be inherited from in Kotlin. =)

KB-11774

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?