### PR TITLE
Fix un-shared dependency in the public API of datex-poller #patch

### DIFF
--- a/modules/datex-poller/build.gradle.kts
+++ b/modules/datex-poller/build.gradle.kts
@@ -4,5 +4,5 @@ dependencies {
     implementation(project(":gcp-functions"))
     implementation(project(":gcp-storage"))
     implementation(project(":gcp-datastore"))
-    implementation(project(":ktor-client"))
+    api(project(":ktor-client"))
 }


### PR DESCRIPTION
We made a mistake in using the HttpTimeoutSettings in the public API without sharing this dependency with an API configuration

KB-11774

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?